### PR TITLE
Add ability to launch on mybinder.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM rocker/binder:3.4.2
 
-USER rstudio
+USER root
 COPY . $HOME
+RUN chown -R rstudio:rstudio *
+USER rstudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM rocker/binder:3.4.2
+
+COPY . $HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM rocker/binder:3.4.2
 
+USER rstudio
 COPY . $HOME


### PR DESCRIPTION
This is still work in progress.

Adds a little bit of `Dockerfile` magic so that you can launch this on mybinder.org to try it out: https://mybinder.org/v2/gh/betatim/2017-11-bands/binder With Binder you can open the R notebook in an executable environment, making it immediately run- and editable, without having to install anything. If you follow the above link, wait for it to build, then click `New -> RStudio session` to get RStudio in your browser. From there it should be familiar for R users on how to re-run the notebook.

👍  for publishing this directly with the article! I just tried it and unlike so many things that claim to be reproducible, this just works!